### PR TITLE
fix split_ids (returned only (id, 0))

### DIFF
--- a/utils/load.py
+++ b/utils/load.py
@@ -17,7 +17,7 @@ def get_ids(dir):
 
 def split_ids(ids, n=2):
     """Split each id in n, creating n tuples (id, k) for each id"""
-    return ((id, i) for i in range(n) for id in ids)
+    return ((id, i)  for id in ids for i in range(n))
 
 
 def to_cropped_imgs(ids, dir, suffix, scale):


### PR DESCRIPTION
split id was creating only tuples (id, 0) and no (id, 1) causing the network to only train on left side of images. 
Figured it out because i got some systematic artefact on right sides of images.