### PR TITLE
Corrected class Up for model to ONNX exporting

### DIFF
--- a/unet/unet_parts.py
+++ b/unet/unet_parts.py
@@ -54,8 +54,8 @@ class Up(nn.Module):
     def forward(self, x1, x2):
         x1 = self.up(x1)
         # input is CHW
-        diffY = x2.size()[2] - x1.size()[2]
-        diffX = x2.size()[3] - x1.size()[3]
+        diffY = torch.tensor([x2.size()[2] - x1.size()[2]])
+        diffX = torch.tensor([x2.size()[3] - x1.size()[3]])
 
         x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
                         diffY // 2, diffY - diffY // 2])


### PR DESCRIPTION
Hello,

I tried to export this model after training to [ONNX](https://onnx.ai/) format using PyTorch function [torch.onnx.export](https://pytorch.org/docs/stable/onnx.html).
For test I added:
```python
torch.onnx.export(nn.Sequential(net, sigmoid_layer), dummy_input, "saved.onnx", verbose=True)
```
in file [predict.py](https://github.com/milesial/Pytorch-UNet/blob/master/predict.py).
But I got the following error:
```
  File "predict.py", line 149, in <module>
    device=device)
  File "predict.py", line 47, in predict_img
    torch.onnx.export(nn.Sequential(net, sigmoid_layer), dummy_input, "saved.onnx", verbose=True)
  File "D:\anaconda3\lib\site-packages\torch\onnx\__init__.py", line 143, in export
    strip_doc_string, dynamic_axes, keep_initializers_as_inputs)
  File "D:\anaconda3\lib\site-packages\torch\onnx\utils.py", line 66, in export
    dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs)
  File "D:\anaconda3\lib\site-packages\torch\onnx\utils.py", line 382, in _export
    fixed_batch_size=fixed_batch_size)
  File "D:\anaconda3\lib\site-packages\torch\onnx\utils.py", line 262, in _model_to_graph
    fixed_batch_size=fixed_batch_size)
  File "D:\anaconda3\lib\site-packages\torch\onnx\utils.py", line 132, in _optimize_graph
    graph = torch._C._jit_pass_onnx(graph, operator_export_type)
  File "D:\anaconda3\lib\site-packages\torch\onnx\__init__.py", line 174, in _run_symbolic_function
    return utils._run_symbolic_function(*args, **kwargs)
  File "D:\anaconda3\lib\site-packages\torch\onnx\utils.py", line 619, in _run_symbolic_function
    return op_fn(g, *inputs, **attrs)
  File "D:\anaconda3\lib\site-packages\torch\onnx\symbolic_helper.py", line 123, in wrapper
    args = [_parse_arg(arg, arg_desc) for arg, arg_desc in zip(args, arg_descriptors)]
  File "D:\anaconda3\lib\site-packages\torch\onnx\symbolic_helper.py", line 123, in <listcomp>
    args = [_parse_arg(arg, arg_desc) for arg, arg_desc in zip(args, arg_descriptors)]
  File "D:\anaconda3\lib\site-packages\torch\onnx\symbolic_helper.py", line 75, in _parse_arg
    raise RuntimeError("Failed to export an ONNX attribute, "
RuntimeError: Failed to export an ONNX attribute, since it's not constant, please try to make things (e.g., kernel size) static if possible
```

As I found out, the problem is in lines:

https://github.com/milesial/Pytorch-UNet/blob/eb54ef62c6c893ab9e93d4a8095b75044c2d33a7/unet/unet_parts.py#L57-L58

After the proposed changes, export to ONNX occurs without errors.