### PR TITLE
Fixed glob in dataset

### DIFF
--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -43,8 +43,8 @@ class BasicDataset(Dataset):
 
     def __getitem__(self, i):
         idx = self.ids[i]
-        mask_file = glob(self.masks_dir + idx + '*')
-        img_file = glob(self.imgs_dir + idx + '*')
+        mask_file = glob(self.masks_dir + idx + '.*')
+        img_file = glob(self.imgs_dir + idx + '.*')
 
         assert len(mask_file) == 1, \
             f'Either no mask or multiple masks found for the ID {idx}: {mask_file}'


### PR DESCRIPTION
Glob is used here:

https://github.com/milesial/Pytorch-UNet/blob/02644ec8e673f54006c8cc1523610e149e84ceb5/utils/dataset.py#L46

and here:

https://github.com/milesial/Pytorch-UNet/blob/02644ec8e673f54006c8cc1523610e149e84ceb5/utils/dataset.py#L47

but this construct has a flaw. For instance an `id` of `image2` can match masks or images having this prefix including `image2.jpg`, `image21.jpg` and so on.

Glob should match the `id` up to the file extension, not only as a prefix. This can be achieved by including a `.` before the wildcard: `.*`.