### PR TITLE
Fixed Dataloader for batch size greater than one

### DIFF
--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -59,4 +59,7 @@ class BasicDataset(Dataset):
         img = self.preprocess(img, self.scale)
         mask = self.preprocess(mask, self.scale)
 
-        return {'image': torch.from_numpy(img), 'mask': torch.from_numpy(mask)}
+        return {
+            'image': torch.from_numpy(img).type(torch.FloatTensor),
+            'mask': torch.from_numpy(mask).type(torch.FloatTensor)
+        }


### PR DESCRIPTION
Using a batch size greater than one can sometimes crash because of if [this issue](https://discuss.pytorch.org/t/runtimeerror-expected-object-of-scalar-type-double-but-got-scalar-type-long-for-sequence-element-1-in-sequence-argument-at-position-1-tensors/46952/4).

This pull request fixes the issue by converting to `FloatTensor` before returning the tensors in `Dataset` subscript.