### PR TITLE
W&B: Add wandb login prompt with timeout

### DIFF
--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+import pkg_resources as pkg
 
 import torch
 import torch.nn as nn
@@ -47,7 +48,14 @@ def train_net(net,
     val_loader = DataLoader(val_set, shuffle=False, drop_last=True, **loader_args)
 
     # (Initialize logging)
-    experiment = wandb.init(project='U-Net', resume='allow', anonymous='must')
+    anonymous = 'must'
+    mode = 'online'
+    if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.2'):
+        wandb_login_success = wandb.login(timeout=30)
+        if wandb_login_success:
+            anonymous = 'never'
+
+    experiment = wandb.init(project='U-Net', resume='allow', mode=mode, anonymous=anonymous)
     experiment.config.update(dict(epochs=epochs, batch_size=batch_size, learning_rate=learning_rate,
                                   val_percent=val_percent, save_checkpoint=save_checkpoint, img_scale=img_scale,
                                   amp=amp))


### PR DESCRIPTION
This PR:
* ### Adds support for wandb login prompt with a timeout.
 The prompt shows up only if you're not already logged in.
**Case 1: When you're already logged in:**
    (This will directly start logging in your wandb account)
![Screenshot from 2021-10-19 03-14-21](https://user-images.githubusercontent.com/15766192/137812185-f7c2ac72-8973-44e5-b4b5-395b4c53a428.png)
**Case 2: When you're not logged in and login times out**
(this will log anonymode runs)
![Screenshot from 2021-10-19 03-31-15](https://user-images.githubusercontent.com/15766192/137812822-afe4ac1a-9dfd-48a9-8cda-47171342ea57.png)

