### PR TITLE
I found an error in multi-category segmentation

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,7 +130,7 @@ def train_net(net,
                             'images': wandb.Image(images[0].cpu()),
                             'masks': {
                                 'true': wandb.Image(true_masks[0].float().cpu()),
-                                'pred': wandb.Image(torch.softmax(masks_pred, dim=1)[0].float().cpu()),
+                                'pred': wandb.Image(torch.softmax(masks_pred, dim=1).argmax(dim=1)[0].float().cpu()),
                             },
                             'step': global_step,
                             'epoch': epoch,


### PR DESCRIPTION
Solved the problem that ‘wandb’ could not display masks_pred in the multi-category segmentation problem.If we do not modify it, we may encounter the following error message:‘mode, rawmode = _fromarray_typemap[typekey] KeyError: ((1, 1, 15), '|u1').ps:15 is the number of categories’.