### PR TITLE
Allow for full-RGB mask channels

### DIFF
--- a/utils/data_loading.py
+++ b/utils/data_loading.py
@@ -33,7 +33,10 @@ class BasicDataset(Dataset):
         pil_img = pil_img.resize((newW, newH), resample=Image.NEAREST if is_mask else Image.BICUBIC)
         img_ndarray = np.asarray(pil_img)
 
-        if not is_mask:
+        if is_mask:
+            if img_ndarray.ndim > 2:
+                img_ndarray = img_ndarray.sum(axis=-1, dtype=img_ndarray.dtype)
+        else:
             if img_ndarray.ndim == 2:
                 img_ndarray = img_ndarray[np.newaxis, ...]
             else:


### PR DESCRIPTION
fix #350
What can still go wrong after this edit is 1) the number of classes, because there can now be at most 3*255 of them, and 2) the fact that a `#f00` region and a `#0f0` region will end up being considered as the same masked segment.
But actually treating the full-RGB images passed as mask is better, in my opinion.

Some may argue that this can pass the above-mentioned errors silently. In that case, I would argue for my `if img_ndarray.ndim > 2` to raise an exception, rather than keeping the current behavior which also passes errors silently.