### PR TITLE
Disallow mismanaged npz files in data loading

### DIFF
--- a/utils/data_loading.py
+++ b/utils/data_loading.py
@@ -46,7 +46,7 @@ class BasicDataset(Dataset):
     @staticmethod
     def load(filename):
         ext = splitext(filename)[1]
-        if ext in ['.npz', '.npy']:
+        if ext == '.npy':
             return Image.fromarray(np.load(filename))
         elif ext in ['.pt', '.pth']:
             return Image.fromarray(torch.load(filename).numpy())


### PR DESCRIPTION
The numpy.load function does accept .npz files, but if given one the function doesn't return an array, which is necessary for the Image.fromarray function to work properly.