### PR TITLE
fix: the tqdm misprinting out of Evaluation logic error

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,32 +110,32 @@ def train_net(net,
                 })
                 pbar.set_postfix(**{'loss (batch)': loss.item()})
 
-                # Evaluation round
-                division_step = (n_train // (10 * batch_size))
-                if division_step > 0:
-                    if global_step % division_step == 0:
-                        histograms = {}
-                        for tag, value in net.named_parameters():
-                            tag = tag.replace('/', '.')
-                            histograms['Weights/' + tag] = wandb.Histogram(value.data.cpu())
-                            histograms['Gradients/' + tag] = wandb.Histogram(value.grad.data.cpu())
+        # Evaluation round
+        division_step = (n_train // (10 * batch_size))
+        if division_step > 0:
+            if global_step % division_step == 0:
+                histograms = {}
+                for tag, value in net.named_parameters():
+                    tag = tag.replace('/', '.')
+                    histograms['Weights/' + tag] = wandb.Histogram(value.data.cpu())
+                    histograms['Gradients/' + tag] = wandb.Histogram(value.grad.data.cpu())
 
-                        val_score = evaluate(net, val_loader, device)
-                        scheduler.step(val_score)
+                val_score = evaluate(net, val_loader, device)
+                scheduler.step(val_score)
 
-                        logging.info('Validation Dice score: {}'.format(val_score))
-                        experiment.log({
-                            'learning rate': optimizer.param_groups[0]['lr'],
-                            'validation Dice': val_score,
-                            'images': wandb.Image(images[0].cpu()),
-                            'masks': {
-                                'true': wandb.Image(true_masks[0].float().cpu()),
-                                'pred': wandb.Image(torch.softmax(masks_pred, dim=1).argmax(dim=1)[0].float().cpu()),
-                            },
-                            'step': global_step,
-                            'epoch': epoch,
-                            **histograms
-                        })
+                logging.info('Validation Dice score: {}'.format(val_score))
+                experiment.log({
+                    'learning rate': optimizer.param_groups[0]['lr'],
+                    'validation Dice': val_score,
+                    'images': wandb.Image(images[0].cpu()),
+                    'masks': {
+                        'true': wandb.Image(true_masks[0].float().cpu()),
+                        'pred': wandb.Image(torch.softmax(masks_pred, dim=1).argmax(dim=1)[0].float().cpu()),
+                    },
+                    'step': global_step,
+                    'epoch': epoch,
+                    **histograms
+                })
 
         if save_checkpoint:
             Path(dir_checkpoint).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
In train.py, the evaluation should be placed at the same level with training: line 78 "with tqdm(total=n_train, desc=f'Epoch {epoch}/{epochs}', unit='img') as pbar:"
In the original way, some misprinting of tqdm bar may occur, since tqdm doesn't shut down and still counting during eval.
After the test under the original dataset, the changed code can run perfectly. 
