### PR TITLE
Fixed prediction plotting where only class with ID 1 was plotted.

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -9,7 +9,7 @@ def plot_img_and_mask(img, mask):
     if classes > 1:
         for i in range(classes):
             ax[i + 1].set_title(f'Output mask (class {i + 1})')
-            ax[i + 1].imshow(mask[1, :, :])
+            ax[i + 1].imshow(mask[i, :, :])
     else:
         ax[1].set_title(f'Output mask')
         ax[1].imshow(mask)


### PR DESCRIPTION
When the predicted mask contained more than one class, only the class with ID 1 was plotted.
This resulted in displaying as many plots as classes in `mask`, but only showing results for class ID 1.