### PR TITLE
Fixing popping "mask_values" when loading checkpoint

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -15,7 +15,8 @@ def unet_carvana(pretrained=False, scale=0.5):
         else:
             raise RuntimeError('Only 0.5 and 1.0 scales are available')
         state_dict = torch.hub.load_state_dict_from_url(checkpoint, progress=True)
-        state_dict.pop('mask_values')
+        if 'mask_values' in state_dict:
+            state_dict.pop('mask_values')
         net.load_state_dict(state_dict)
 
     return net


### PR DESCRIPTION
## Summary


Using `model = torch.hub.load("milesial/Pytorch-UNet", "unet_carvana", pretrained=True, scale=0.5)` or `scale=1.0` results in
```
model = torch.hub.load("milesial/Pytorch-UNet", "unet_carvana", pretrained=True, scale=0.5)
Using cache found in /home/craig/.cache/torch/hub/milesial_Pytorch-UNet_master
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[4], line 1
----> 1 model = torch.hub.load("milesial/Pytorch-UNet", "unet_carvana", pretrained=True, scale=0.5)

File ~/.pyenv/versions/3.9.11/envs/torch/lib/python3.9/site-packages/torch/hub.py:542, in load(repo_or_dir, model, source, trust_repo, force_reload, verbose, skip_validation, *args, **kwargs)
    538 if source == 'github':
    539     repo_or_dir = _get_cache_or_reload(repo_or_dir, force_reload, trust_repo, "load",
    540                                        verbose=verbose, skip_validation=skip_validation)
--> 542 model = _load_local(repo_or_dir, model, *args, **kwargs)
    543 return model

File ~/.pyenv/versions/3.9.11/envs/torch/lib/python3.9/site-packages/torch/hub.py:572, in _load_local(hubconf_dir, model, *args, **kwargs)
    569 hub_module = _import_module(MODULE_HUBCONF, hubconf_path)
    571 entry = _load_entry_from_hubconf(hub_module, model)
--> 572 model = entry(*args, **kwargs)
    574 sys.path.remove(hubconf_dir)
    576 return model

File ~/.cache/torch/hub/milesial_Pytorch-UNet_master/hubconf.py:18, in unet_carvana(pretrained, scale)
     16         raise RuntimeError('Only 0.5 and 1.0 scales are available')
     17     state_dict = torch.hub.load_state_dict_from_url(checkpoint, progress=True)
---> 18     state_dict.pop('mask_values')
     19     net.load_state_dict(state_dict)
     21 return net

KeyError: 'mask_values'
```

Using `unet_carvana` from `hubconf.py` directly from this repo results in the same error. This PR checks for the `mask_values` keys before popping.

## Tests
Tested on:
Ubuntu 20.04
Python 3.9.11
PyTorch 1.13.0+cu116

```
from hubconf import unet_carvana
model_05 = unet_carvana(pretrained=True, scale=0.5)
model_10 = unet_carvana(pretrained=True, scale=1.0)
```

Results in successful loading of the checkpoint.
