### PR TITLE
Fix the shape assertion error in the evaluation stage of one-class se…

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -27,7 +27,7 @@ def evaluate(net, dataloader, device, amp):
                 assert mask_true.min() >= 0 and mask_true.max() <= 1, 'True mask indices should be in [0, 1]'
                 mask_pred = (F.sigmoid(mask_pred) > 0.5).float()
                 # compute the Dice score
-                dice_score += dice_coeff(mask_pred, mask_true, reduce_batch_first=False)
+                dice_score += dice_coeff(mask_pred.squeeze(1), mask_true, reduce_batch_first=False)
             else:
                 assert mask_true.min() >= 0 and mask_true.max() < net.n_classes, 'True mask indices should be in [0, n_classes['
                 # convert to one-hot format


### PR DESCRIPTION
Hello,

I have detected an assertion error bug in evaluation stage of one class segmentation situation.

To fix this, I made a change as follow: 

```
diff --git a/evaluate.py b/evaluate.py
index 9a4e3ba..42eb064 100644
--- a/evaluate.py
+++ b/evaluate.py
@@ -27,7 +27,7 @@ def evaluate(net, dataloader, device, amp):
                 assert mask_true.min() >= 0 and mask_true.max() <= 1, 'True mask indices should be in [0, 1]'
                 mask_pred = (F.sigmoid(mask_pred) > 0.5).float()
                 # compute the Dice score
-                dice_score += dice_coeff(mask_pred, mask_true, reduce_batch_first=False)
+                dice_score += dice_coeff(mask_pred.squeeze(1), mask_true, reduce_batch_first=False)
```

Although it is very easy, I believe that my bug fix resolves the issue effectively and improves the overall stability and functionality of the project.

Please review the changes and let me know if any further modifications or adjustments are required. I am open to feedback and suggestions to make the solution even better.

Thank you for your time and consideration.

Best regards