### PR TITLE
Unscale gradients before clipping

### DIFF
--- a/train.py
+++ b/train.py
@@ -112,6 +112,7 @@ def train_model(
 
                 optimizer.zero_grad(set_to_none=True)
                 grad_scaler.scale(loss).backward()
+                grad_scaler.unscale_(optimizer)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), gradient_clipping)
                 grad_scaler.step(optimizer)
                 grad_scaler.update()


### PR DESCRIPTION
Gradients should be unscaled before clipping them.
[PyTorch Guide to use AMP](https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html#inspecting-modifying-gradients-e-g-clipping)