### PR TITLE
Change the checkpoint code

### DIFF
--- a/unet/unet_model.py
+++ b/unet/unet_model.py
@@ -1,5 +1,7 @@
 """ Full assembly of the parts to form the complete network """
 
+import torch.utils.checkpoint as cp
+
 from .unet_parts import *
 
 
@@ -9,6 +11,7 @@ class UNet(nn.Module):
         self.n_channels = n_channels
         self.n_classes = n_classes
         self.bilinear = bilinear
+        self.use_checkpointing = False
 
         self.inc = (DoubleConv(n_channels, 64))
         self.down1 = (Down(64, 128))
@@ -23,26 +26,19 @@ class UNet(nn.Module):
         self.outc = (OutConv(64, n_classes))
 
     def forward(self, x):
-        x1 = self.inc(x)
-        x2 = self.down1(x1)
-        x3 = self.down2(x2)
-        x4 = self.down3(x3)
-        x5 = self.down4(x4)
-        x = self.up1(x5, x4)
-        x = self.up2(x, x3)
-        x = self.up3(x, x2)
-        x = self.up4(x, x1)
+        def run(module, *inputs):
+            if self.use_checkpointing:
+                return cp.checkpoint(module, *inputs, use_reentrant=False)
+            return module(*inputs)
+
+        x1 = run(self.inc, x)
+        x2 = run(self.down1, x1)
+        x3 = run(self.down2, x2)
+        x4 = run(self.down3, x3)
+        x5 = run(self.down4, x4)
+        x = run(self.up1, x5, x4)
+        x = run(self.up2, x, x3)
+        x = run(self.up3, x, x2)
+        x = run(self.up4, x, x1)
         logits = self.outc(x)
         return logits
-
-    def use_checkpointing(self):
-        self.inc = torch.utils.checkpoint(self.inc)
-        self.down1 = torch.utils.checkpoint(self.down1)
-        self.down2 = torch.utils.checkpoint(self.down2)
-        self.down3 = torch.utils.checkpoint(self.down3)
-        self.down4 = torch.utils.checkpoint(self.down4)
-        self.up1 = torch.utils.checkpoint(self.up1)
-        self.up2 = torch.utils.checkpoint(self.up2)
-        self.up3 = torch.utils.checkpoint(self.up3)
-        self.up4 = torch.utils.checkpoint(self.up4)
-        self.outc = torch.utils.checkpoint(self.outc)


### PR DESCRIPTION
`torch.utils.checkpoint` is a module, not a function that can be called directly—the actual checkpoint function is `torch.utils.checkpoint.checkpoint`. The object wrapped by `checkpoint` should be a “specific forward pass” (function + input), rather than simply replacing the entire `self.inc` `nn.Module` object—the checkpointing mechanism must know what the input is in order to recompute the forward pass during backpropagation.
